### PR TITLE
Org level correct

### DIFF
--- a/ceqr/recipes/sca_capacity_projects/build.py
+++ b/ceqr/recipes/sca_capacity_projects/build.py
@@ -220,6 +220,11 @@ if __name__ == "__main__":
     # Concatenate tables
     df = df_15_19.append(df_20_24, ignore_index=True)
 
+    # Import csv to replace invalid addresses with manual corrections
+    cor_dict = pd.read_csv('https://raw.githubusercontent.com/NYCPlanning/ceqr-app-data/master/ceqr/data/sca_capacity_address_cor.csv').to_dict('records')
+    for record in cor_dict:
+        df.loc[df['name']==record['school'],'address'] = record['address'].upper()
+
     # Perform column transformation
     df['borough'] = df['borough'].apply(get_boro)
     df['hnum'] = df.address.apply(get_hnum).apply(lambda x: clean_house(x))

--- a/ceqr/recipes/sca_capacity_projects/output/capacity_projects_needgeoms.csv
+++ b/ceqr/recipes/sca_capacity_projects/output/capacity_projects_needgeoms.csv
@@ -1,4 +1,1 @@
 ,name,org_level,capacity,pct_ps,pct_is,pct_hs,guessed_pct,start_date,capital_plan,borough,address,geo_function,geom,geo_grc,geo_grc2,geo_reason_code,geo_message
-0,P.S. @ HUDSON SQUARE,PS,462,1.0,0.0,0.0,False,2025-06-01,20-24,Manhattan,2 HUDSON SQUARE,,,42,42,,ADDRESS NUMBER OUT OF RANGE
-1,I.S. @ 21-31 & 35 DELEVAN STREET,IS,646,0.0,1.0,0.0,False,2025-06-01,20-24,Brooklyn,21-31 & 35 DELEVAN STREET,,,13,13,C,ADDRESS NBR 21-31 35  HAS AN EMBEDDED BLANK.
-2,I.S. @ 44-59 45 AVENUE,IS,536,0.0,1.0,0.0,False,2024-06-01,20-24,Queens,44-59 45 AVENUE,,,42,42,,ADDRESS NUMBER OUT OF RANGE


### PR DESCRIPTION
Adds more checks for multi-org-level schools, removes D75 schools, and incorporates a [manual look-up file](https://github.com/NYCPlanning/ceqr-app-data/blob/master/ceqr/data/sca_capacity_org_level_cor.csv) for schools without org information in their names. 