### PR TITLE
Remove columns from output, retaining them in geo_rejects

### DIFF
--- a/ceqr/recipes/dep_cats_permits/build.py
+++ b/ceqr/recipes/dep_cats_permits/build.py
@@ -153,6 +153,14 @@ if __name__ == "__main__":
                                                 END);
             DELETE FROM {output_table}
             WHERE geom IS NULL;
+
+            ALTER TABLE {output_table}
+            DROP COLUMN address,
+            DROP COLUMN streetname_1,
+            DROP COLUMN streetname_2,
+            DROP COLUMN geo_x_coord,
+            DROP COLUMN geo_y_coord,
+            DROP COLUMN geo_function;
             '''
 
     SQL2 = f'''


### PR DESCRIPTION
Geosupport-related columns only get dropped from the output table. This way we have more information to trace geo rejects.